### PR TITLE
Update license header to enforce 2022 in date

### DIFF
--- a/.mvn/checkstyle/license-header-java-groovy.txt
+++ b/.mvn/checkstyle/license-header-java-groovy.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ashley Scopes
+ * Copyright (C) 2021-2022 Ashley Scopes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- [x] Update Checkstyle header template.
- [ ] Update all files to use new header. e.g. `find -name '*.java' -o -name '*.groovy' -exec sed 's?\* Copyright \(C\) 2021 ?\* Copyright \(C\) 2021-2022 ?g' -i {} \;`
- [ ] Ensure Checkstyle passes.